### PR TITLE
#18 [Feat] 퀘스트 상세 화면 구현

### DIFF
--- a/src/api/hooks/quest/useGetUserMainQuest.ts
+++ b/src/api/hooks/quest/useGetUserMainQuest.ts
@@ -1,0 +1,9 @@
+import { getUserMainQuest } from '@/api/quest';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetUserMainQuest = (userId: string, mainQuestId: string) => {
+  return useQuery({
+    queryKey: ['main-quests', 'user', userId, mainQuestId],
+    queryFn: () => getUserMainQuest(userId, mainQuestId),
+  });
+};

--- a/src/api/quest.ts
+++ b/src/api/quest.ts
@@ -18,6 +18,25 @@ export const getUserMainQuests = async (
   return response.data ?? [];
 };
 
+export const getUserMainQuest = async (
+  userId: string,
+  mainQuestId: string
+): Promise<UserMainQuestDTO> => {
+  const response = await api.get<ApiResponse<UserMainQuestDTO>>(
+    `/users/${userId}/main-quest/${mainQuestId}`
+  );
+  return (
+    response.data ?? {
+      id: '',
+      title: '',
+      startDate: '',
+      endDate: '',
+      attributes: [],
+      createdAt: '',
+    }
+  );
+};
+
 export const getUserSubQuests = async (
   userId: string,
   mainQuestId: string

--- a/src/components/ui/QuestItem/QuestItem.tsx
+++ b/src/components/ui/QuestItem/QuestItem.tsx
@@ -6,13 +6,15 @@ import { getSubQuestFrequencyLabel } from '@/constants/quest';
 const cx = classNames.bind(styles);
 
 export const QuestItem = ({
+  id,
   desc,
   defaultRepeat,
   frequency,
   repeatCnt,
   attributes,
   essential,
-}: UserSubQuest) => {
+  onClick = () => {},
+}: UserSubQuest & { onClick?: (id: string) => void }) => {
   return (
     <div className={cx('quest-item')}>
       <div className={cx('topRow')}>
@@ -39,7 +41,9 @@ export const QuestItem = ({
         </div>
       </div>
       <div className={cx('desc')}>{desc}</div>
-      <button className={cx('confirm')}>인증하기</button>
+      <button className={cx('confirm')} onClick={() => onClick(id)}>
+        인증하기
+      </button>
     </div>
   );
 };

--- a/src/mocks/handler/questHandlers.ts
+++ b/src/mocks/handler/questHandlers.ts
@@ -28,6 +28,15 @@ export const questHandlers = [
       data: quests,
     });
   }),
+  http.get('/users/:userId/main-quest/:mainQuestId', ({ params }) => {
+    const { mainQuestId } = params;
+
+    const quest = mockUserMainQuests.find((quest) => quest.id === mainQuestId);
+
+    return HttpResponse.json({
+      data: quest,
+    });
+  }),
   http.get('/sub-quests', ({ request }) => {
     const params = new URL(request.url).searchParams;
     const limit = params.get('limit');

--- a/src/pages/quest/detail/QuestDetailPage.module.scss
+++ b/src/pages/quest/detail/QuestDetailPage.module.scss
@@ -48,3 +48,9 @@
   color: var(--color-gray-100);
   line-height: 20px;
 }
+
+.quest-component {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}

--- a/src/pages/quest/detail/QuestDetailPage.module.scss
+++ b/src/pages/quest/detail/QuestDetailPage.module.scss
@@ -1,2 +1,50 @@
 .quest-detail {
+  padding: 20px 14px;
+  border-bottom: 1px solid var(--color-gray-700);
+}
+
+.main-quest-date {
+  font-size: 12px;
+  color: var(--color-gray-300);
+  line-height: 17px;
+}
+
+.main-quest-title {
+  display: block;
+  margin-top: 4px;
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--color-white);
+  line-height: 25px;
+}
+
+.reward-list {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  margin-bottom: 32px;
+}
+
+.reward-item {
+  display: flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 146px;
+  background-color: var(--color-gray-600);
+}
+
+.reward-icon {
+  display: block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+}
+
+.reward-text {
+  display: block;
+  flex: 0 0 auto;
+  margin-left: 4px;
+  font-size: 14px;
+  color: var(--color-gray-100);
+  line-height: 20px;
 }

--- a/src/pages/quest/detail/QuestDetailPage.tsx
+++ b/src/pages/quest/detail/QuestDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import { QuestReportBottomSheet } from '@/pages/quest/detail/components/QuestReportBottomSheet/QuestReportBottomSheet';
 import { usePostUserSubQuestLog } from '@/api/hooks/quest/usePostUserSubQuestLog';
@@ -14,6 +15,13 @@ import type {
 
 import classNames from 'classnames/bind';
 import styles from './QuestDetailPage.module.scss';
+import { Header } from '@/components/ui/Header/Header';
+import { getWeeksDifference } from '@/utils/date';
+import { AttributeIcon } from '@/components/ui/AttributeIcon/AttributeIcon';
+import type { AttributeReward } from '@/types/attribute';
+import { QuestList } from '@/pages/status/components/QuestList/QuestList';
+import { useGetUserSubQuests } from '@/api/hooks/quest/useGetUserSubQuests';
+import { useGetUserMainQuest } from '@/api/hooks/quest/useGetUserMainQuest';
 
 const cx = classNames.bind(styles);
 
@@ -33,8 +41,13 @@ const DUMMY_SUB_QUEST: UserSubQuest = {
 };
 
 const QuestDetailPage = () => {
-  // [TODO] 퀘스트 상세 페이지 구현 후 초기값 변경
-  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(true);
+  const { id: mainQuestId } = useParams();
+  const userId = '10';
+
+  const { data: quest } = useGetUserMainQuest(userId, mainQuestId || '');
+  const { data: subQuests } = useGetUserSubQuests(userId, mainQuestId || '');
+
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const [selectedSubQuest, setSelectedSubQuest] = useState<UserSubQuest | null>(
     DUMMY_SUB_QUEST
   );
@@ -92,8 +105,34 @@ const QuestDetailPage = () => {
 
   return (
     <>
+      <Header title="퀘스트 상세" hasBackButton={true} />
       <main className="main">
-        <div className={cx('quest-detail')}></div>
+        {quest && (
+          <div className={cx('quest-detail')}>
+            <span className={cx('main-quest-date')}>
+              기한_{quest.endDate} (총
+              {getWeeksDifference(quest.startDate, quest.endDate)}
+              주)
+            </span>
+            <strong className={cx('main-quest-title')}>{quest.title}</strong>
+            <ul className={cx('reward-list')}>
+              {quest.attributes?.map((attribute: AttributeReward) => (
+                <li key={attribute.attributeId} className={cx('reward-item')}>
+                  <AttributeIcon id={attribute.attributeId} />
+                  <span className={cx('reward-text')}>+{attribute.exp}xp</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <QuestList
+          quests={subQuests || []}
+          className="quest-detail-header"
+          onClick={(quest) => {
+            setIsBottomSheetOpen(true);
+            setSelectedSubQuest(quest);
+          }}
+        />
       </main>
       <QuestReportBottomSheet
         isBottomSheetOpen={isBottomSheetOpen}

--- a/src/pages/quest/detail/QuestDetailPage.tsx
+++ b/src/pages/quest/detail/QuestDetailPage.tsx
@@ -22,6 +22,8 @@ import type { AttributeReward } from '@/types/attribute';
 import { QuestList } from '@/pages/status/components/QuestList/QuestList';
 import { useGetUserSubQuests } from '@/api/hooks/quest/useGetUserSubQuests';
 import { useGetUserMainQuest } from '@/api/hooks/quest/useGetUserMainQuest';
+import TodayCompletedQuests from './components/TodayCompletedQuests/TodayCompletedQuests';
+import CompletedHistory from './components/CompletedHistory/CompletedHistory';
 
 const cx = classNames.bind(styles);
 
@@ -125,14 +127,18 @@ const QuestDetailPage = () => {
             </ul>
           </div>
         )}
-        <QuestList
-          quests={subQuests || []}
-          className="quest-detail-header"
-          onClick={(quest) => {
-            setIsBottomSheetOpen(true);
-            setSelectedSubQuest(quest);
-          }}
-        />
+        <div className={cx('quest-component')}>
+          <QuestList
+            quests={subQuests || []}
+            className="quest-detail-header"
+            onClick={(quest) => {
+              setIsBottomSheetOpen(true);
+              setSelectedSubQuest(quest);
+            }}
+          />
+          <TodayCompletedQuests />
+          <CompletedHistory />
+        </div>
       </main>
       <QuestReportBottomSheet
         isBottomSheetOpen={isBottomSheetOpen}

--- a/src/pages/quest/detail/components/CompletedHistory/CompletedHistory.module.scss
+++ b/src/pages/quest/detail/components/CompletedHistory/CompletedHistory.module.scss
@@ -1,0 +1,9 @@
+.container {
+  padding: 14px;
+}
+
+.header {
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 22px;
+}

--- a/src/pages/quest/detail/components/CompletedHistory/CompletedHistory.tsx
+++ b/src/pages/quest/detail/components/CompletedHistory/CompletedHistory.tsx
@@ -1,0 +1,18 @@
+import classNames from 'classnames/bind';
+import styles from './CompletedHistory.module.scss';
+
+const cx = classNames.bind(styles);
+
+const CompletedHistory = () => {
+  return (
+    <>
+      <main className="main">
+        <div className={cx('container')}>
+          <div className={cx('header')}>완료 히스토리</div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default CompletedHistory;

--- a/src/pages/quest/detail/components/TodayCompletedQuests/TodayCompletedQuests.module.scss
+++ b/src/pages/quest/detail/components/TodayCompletedQuests/TodayCompletedQuests.module.scss
@@ -1,0 +1,8 @@
+.container {
+  padding: 14px;
+}
+.header {
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 22px;
+}

--- a/src/pages/quest/detail/components/TodayCompletedQuests/TodayCompletedQuests.tsx
+++ b/src/pages/quest/detail/components/TodayCompletedQuests/TodayCompletedQuests.tsx
@@ -1,0 +1,18 @@
+import classNames from 'classnames/bind';
+import styles from './TodayCompletedQuests.module.scss';
+
+const cx = classNames.bind(styles);
+
+const TodayCompletedQuests = () => {
+  return (
+    <>
+      <main className="main">
+        <div className={cx('container')}>
+          <div className={cx('header')}>오늘 완료한 퀘스트</div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default TodayCompletedQuests;

--- a/src/pages/status/StatusPage.tsx
+++ b/src/pages/status/StatusPage.tsx
@@ -7,6 +7,7 @@ import { useGetUserSubQuests } from '@/api/hooks/quest/useGetUserSubQuests';
 import { useState } from 'react';
 import { StatusDetailBottomSheet } from './components/BottomSheet/StatusBottomSheet/StatusBottomSheet';
 import TierLevelBottomSheet from './components/BottomSheet/TierBottomSheet/TierBottomSheet';
+import type { UserSubQuest } from '@/types/quest';
 
 const selectedStatusDefault = {
   value: 0,
@@ -37,7 +38,6 @@ const StatusPage = () => {
           nickname={userInfo.nickname}
           tier={userInfo.tier}
           level={userInfo.level}
-          levelPercent={userInfo.levelPercent}
           profileImageUrl={userInfo.profileImageUrl}
           onClick={() => setIsLevelBottomSheetOpen(true)}
         />
@@ -54,7 +54,14 @@ const StatusPage = () => {
             }}
           />
         )}
-        {quests && <QuestList quests={quests} />}
+        {quests && (
+          <QuestList
+            quests={quests}
+            onClick={(quest: UserSubQuest) => {
+              console.log(quest);
+            }}
+          />
+        )}
       </main>
       <TierLevelBottomSheet
         isOpen={isLevelBottomSheetOpen}

--- a/src/pages/status/components/Header/Header.tsx
+++ b/src/pages/status/components/Header/Header.tsx
@@ -1,11 +1,15 @@
 import classNames from 'classnames/bind';
 import styles from './Header.module.scss';
-import type { UserInfo } from '@/types/user';
 import { TierIcon } from '@/components/ui/TierIcon/TierIcon';
+import type { TierType } from '@/types/tier';
 
 const cx = classNames.bind(styles);
 
-interface HeaderProps extends UserInfo {
+interface HeaderProps {
+  nickname: string;
+  tier: TierType;
+  level: number;
+  profileImageUrl: string;
   onClick: () => void;
 }
 
@@ -13,11 +17,9 @@ export const Header = ({
   nickname,
   tier,
   level,
-  levelPercent,
   profileImageUrl,
   onClick,
 }: HeaderProps) => {
-  console.log(levelPercent);
   return (
     <header className={cx('header')}>
       <div className={cx('profile')}>

--- a/src/pages/status/components/QuestList/QuestList.module.scss
+++ b/src/pages/status/components/QuestList/QuestList.module.scss
@@ -11,3 +11,11 @@
 
   color: var(--color-white);
 }
+
+.quest-detail-header {
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 22px;
+  margin-bottom: 12px;
+  color: var(--color-white);
+}

--- a/src/pages/status/components/QuestList/QuestList.tsx
+++ b/src/pages/status/components/QuestList/QuestList.tsx
@@ -6,12 +6,20 @@ import type { UserSubQuest } from '@/types/quest';
 
 const cx = classNames.bind(styles);
 
-export const QuestList = ({ quests }: { quests: UserSubQuest[] }) => {
+export const QuestList = ({
+  quests,
+  className,
+  onClick,
+}: {
+  quests: UserSubQuest[];
+  className?: string;
+  onClick: (quest: UserSubQuest) => void;
+}) => {
   return (
-    <div className={cx('container')}>
+    <div className={cx('container', className)}>
       <div className={cx('header')}>오늘의 퀘스트</div>
-      {quests.map((quest, idx) => (
-        <QuestItem key={idx} {...quest} />
+      {quests.map((quest) => (
+        <QuestItem key={quest.id} {...quest} onClick={() => onClick(quest)} />
       ))}
     </div>
   );

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -54,6 +54,10 @@ export const router = createBrowserRouter([
             path: PAGE_PATHS.PROFILE,
             Component: ProfilePage,
           },
+          {
+            path: PAGE_PATHS.QUEST_DETAIL,
+            Component: QuestDetailPage,
+          },
         ],
       },
       {
@@ -80,10 +84,7 @@ export const router = createBrowserRouter([
         path: PAGE_PATHS.QUEST_NEW_RESULT,
         Component: StepResultPage,
       },
-      {
-        path: PAGE_PATHS.QUEST_DETAIL,
-        Component: QuestDetailPage,
-      },
+
       {
         path: PAGE_PATHS.LOGIN,
         Component: LoginPage,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

feat/#18-> dev

### 작업 내용

퀘스트 화면 구현
- 이제 퀘스트 포기랑 인증 수정만 구현하면 됩니다~
- 일단 이미지는 뺴고 작업했어요

### 테스트 결과

<img width="384" height="663" alt="image" src="https://github.com/user-attachments/assets/0fc7bba3-bcaa-428b-b9f9-36342c15bf72" />
<img width="404" height="655" alt="image" src="https://github.com/user-attachments/assets/aa979407-aac7-4ead-b8b0-2c219d1a319d" />

- [x] 정상 작동!

### 리뷰 요구사항

- 오늘 완료한 퀘스트를 일단 여러개 있을수 있다는 가정하에 복수건으로 구현
- 퀘스트 인증 수정 바텀시트의 경우 기존 퀘스트 인증하기 화면 재사용 예정
