### PR TITLE
#51 [feat] API 및 훅 수정: 사용자 ID 제거 및 서브 퀘스트 로그 응답 형식 변경

### DIFF
--- a/src/api/hooks/quest/useGetUserMainQuests.ts
+++ b/src/api/hooks/quest/useGetUserMainQuests.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { getUserMainQuests } from '@/api/quest';
 
-export const useGetUserMainQuests = (userId: string) => {
+export const useGetUserMainQuests = () => {
   return useQuery({
-    queryKey: ['main-quests', 'user', userId],
-    queryFn: () => getUserMainQuests(userId),
+    queryKey: ['main-quests', 'user'],
+    queryFn: () => getUserMainQuests(),
   });
 };

--- a/src/api/hooks/user/useGetUserInfo.ts
+++ b/src/api/hooks/user/useGetUserInfo.ts
@@ -1,9 +1,9 @@
 import { getUserInfo } from '@/api/users';
 import { useQuery } from '@tanstack/react-query';
 
-export const useGetUserInfo = (userId: string) => {
+export const useGetUserInfo = () => {
   return useQuery({
-    queryKey: ['user', userId],
-    queryFn: () => getUserInfo(userId),
+    queryKey: ['user'],
+    queryFn: () => getUserInfo(),
   });
 };

--- a/src/api/quest.ts
+++ b/src/api/quest.ts
@@ -15,6 +15,7 @@ import type {
   GetSubQuestsParams,
   RerollSubQuestRequestDTO,
   CreateQuestRequestDTO,
+  UserSubQuestLogResponseDTO,
 } from '@/api/types/quest';
 import type { ApiResponse } from '@/api/types/api';
 import type { ThemeResponseDTO } from '@/api/types/quest';
@@ -126,12 +127,8 @@ export const postCreationQuest = async (data: CreateQuestRequestDTO) => {
   return response.data ?? {};
 };
 
-export const getUserMainQuests = async (
-  userId: string
-): Promise<UserMainQuestDTO[]> => {
-  const response = await api.get<ApiResponse<UserMainQuestDTO[]>>(
-    `/users/${userId}/main-quests`
-  );
+export const getUserMainQuests = async (): Promise<UserMainQuestDTO[]> => {
+  const response = await api.get<ApiResponse<UserMainQuestDTO[]>>(`/quest/me`);
   return response.data ?? [];
 };
 
@@ -171,12 +168,21 @@ export const getUserSubQuests = async (
  * [TODO] 퀘스트 인증 시 서브 퀘스트 인증 상태 patch, 서브 퀘스트 로그 post 트랜잭션 처리 필요. 서버에서 처리가 최적
  * @param data - API 구현에 따라 파라미터 타입 변경 필요
  */
-export const postUserSubQuestLog = async (data: UserSubQuestLogRequestDTO) => {
-  const response = await api.post<ApiResponse<UserSubQuestLogRequestDTO>>(
+export const postUserSubQuestLog = async (
+  data: UserSubQuestLogRequestDTO
+): Promise<UserSubQuestLogResponseDTO> => {
+  const response = await api.post<ApiResponse<UserSubQuestLogResponseDTO>>(
     `/quest/sub`,
     data
   );
-  return response.data ?? {};
+
+  return (
+    response.data ?? {
+      subQuestRewards: [],
+      mainQuestRewards: [],
+      isMainQuestCompleted: false,
+    }
+  );
 };
 
 export const patchUserSubQuestLog = async (data: UserSubQuestLogRequestDTO) => {
@@ -208,7 +214,7 @@ export const getUserCompletedHistory = async (
 export const postUserGiveUpMainQuest = async (
   data: UserMainQuestGiveUpRequestDTO
 ) => {
-  const response = await api.post<ApiResponse<UserMainQuestGiveUpRequestDTO>>(
+  const response = await api.delete<ApiResponse<UserMainQuestGiveUpRequestDTO>>(
     `/quest/${data.id}`
   );
   return response.data ?? {};

--- a/src/api/types/quest.ts
+++ b/src/api/types/quest.ts
@@ -90,6 +90,7 @@ export interface UserSubQuestDTO {
   userSubQuest: SubQuestDTO;
   repeatCnt: number;
   essential: boolean;
+  mainQuestId?: number;
 }
 
 export interface GetMainQuestsParams {
@@ -115,14 +116,24 @@ export interface UserSubQuestLogRequestDTO {
   memo: string;
 }
 
-export interface UserSubQuestLogResponseDTO {
+export interface Rewards {
   id: number;
-  userId: string;
-  userSubQuestId: string;
-  difficulty: SubQuestDifficulty;
-  status: string;
-  createdAt: string;
+  name: string;
+  exp: number;
 }
+export interface UserSubQuestLogResponseDTO {
+  subQuestRewards: Rewards[];
+  mainQuestRewards: Rewards[];
+  isMainQuestCompleted: boolean;
+}
+// export interface UserSubQuestLogResponseDTO {
+//   id: number;
+//   userId: string;
+//   userSubQuestId: string;
+//   difficulty: SubQuestDifficulty;
+//   status: string;
+//   createdAt: string;
+// }
 
 export interface CompletedQuestDTO extends UserSubQuestDTO {
   log: {

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -6,10 +6,8 @@ import type {
 } from '@/api/types/users';
 import type { ApiResponse } from '@/api/types/api';
 
-export const getUserInfo = async (userId: string): Promise<UserInfoDTO> => {
-  const response = await api.get<ApiResponse<UserInfoDTO>>(
-    `/users/${userId}/userInfo`
-  );
+export const getUserInfo = async (): Promise<UserInfoDTO> => {
+  const response = await api.get<ApiResponse<UserInfoDTO>>(`/user`);
   return (
     response.data ?? {
       id: '',

--- a/src/mocks/data/quest.ts
+++ b/src/mocks/data/quest.ts
@@ -361,3 +361,21 @@ export const mockCompletedHistory = getRecentDates(4).map((date) => ({
   date,
   logs: mockTodayCompletedQuests,
 }));
+
+export const mockSubQuestLogResponse = {
+  subQuestRewards: [
+    {
+      id: 0,
+      name: 'string',
+      exp: 0,
+    },
+  ],
+  mainQuestRewards: [
+    {
+      id: 0,
+      name: 'string',
+      exp: 0,
+    },
+  ],
+  isMainQuestCompleted: true,
+};

--- a/src/mocks/handler/questHandlers.ts
+++ b/src/mocks/handler/questHandlers.ts
@@ -5,6 +5,7 @@ import {
   mockUserMainQuests,
   mockUserSubQuests,
   mockCompletedHistory,
+  mockSubQuestLogResponse,
 } from '@/mocks/data/quest';
 import type {
   CreateQuestRequestDTO,
@@ -146,7 +147,11 @@ export const questHandlers = [
     });
   }),
 
-  http.get(`${API_URL}/users/:userId/main-quests`, () => {
+  http.get(`${API_URL}/quest/me`, () => {
+    if (import.meta.env.MODE !== 'development') {
+      return passthrough();
+    }
+
     return HttpResponse.json({
       data: mockUserMainQuests,
     });
@@ -191,8 +196,7 @@ export const questHandlers = [
     if (import.meta.env.MODE !== 'development') {
       return passthrough();
     }
-
-    const requestData = (await request.json()) as UserSubQuestLogResponseDTO;
+    console.log(request);
 
     // [TODO] 서브 퀘스트 인증 상태 업데이트
     // const userSubQuest = mockUserSubQuests.find(
@@ -200,7 +204,7 @@ export const questHandlers = [
     // );
 
     return HttpResponse.json({
-      data: requestData,
+      data: mockSubQuestLogResponse,
     });
   }),
 
@@ -228,7 +232,7 @@ export const questHandlers = [
       data: mockCompletedHistory,
     });
   }),
-  http.post(`${API_URL}/quest/:mainQuestId`, () => {
+  http.delete(`${API_URL}/quest/:mainQuestId`, () => {
     return HttpResponse.json({
       data: {},
     });

--- a/src/mocks/handler/usersHandlers.ts
+++ b/src/mocks/handler/usersHandlers.ts
@@ -6,7 +6,7 @@ import { getCookie } from '@/utils/cookie';
 export const API_URL = import.meta.env.VITE_API_URL;
 
 export const usersHandlers = [
-  http.get(`${API_URL}/users/:userId/userInfo`, ({ params }) => {
+  http.get(`${API_URL}/user`, ({ params }) => {
     // const userId = params.userId as string;
     console.log(params);
 

--- a/src/pages/quest/QuestPage.tsx
+++ b/src/pages/quest/QuestPage.tsx
@@ -16,8 +16,8 @@ const cx = classNames.bind(styles);
 export const QuestPage = () => {
   const navigate = useNavigate();
   // [TODO] auth store에서 사용자 정보 가져오기
-  const userId = '10';
-  const { data } = useGetUserMainQuests(userId);
+  // const userId = '10';
+  const { data } = useGetUserMainQuests();
 
   const handleAddQuest = () => {
     navigate(PAGE_PATHS.QUEST_NEW_ATTRIBUTE);

--- a/src/pages/status/StatusPage.tsx
+++ b/src/pages/status/StatusPage.tsx
@@ -13,9 +13,7 @@ import { PAGE_PATHS } from '@/constants/pagePaths';
 
 const StatusPage = () => {
   const navigate = useNavigate();
-  const userId = '10';
-  const mainQuestId = '1';
-  const { data: userInfo } = useGetUserInfo(userId);
+  const { data: userInfo } = useGetUserInfo();
   const { data: attributeDatas } = useGetUserAttributes();
   const { data: quests } = useGetUserSubQuestsAll();
   console.log(quests);
@@ -60,10 +58,8 @@ const StatusPage = () => {
             quests={quests}
             onClick={(_, quest: UserSubQuest) => {
               navigate(
-                `${PAGE_PATHS.QUEST_DETAIL.replace(':id', mainQuestId)}`,
-                {
-                  state: { quest: quest },
-                }
+                `${PAGE_PATHS.QUEST_DETAIL.replace(':id', quest.mainQuestId?.toString() || '')}`,
+                { state: { quest: quest } }
               );
             }}
           />


### PR DESCRIPTION
- 사용자 ID를 API 호출에서 제거하여 현재 사용자 정보를 자동으로 가져오도록 수정
- 서브 퀘스트 로그 API 응답 형식을 변경하여 보상 정보를 포함하도록 업데이트
- 관련된 훅 및 페이지에서 사용자 ID를 제거하고 API 호출을 간소화함

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

feat/51 -> dev

### 작업 내용

- 메인퀘스트 목록 API 
- 디코 피드백 반영
- 상태창 -> 서브퀘스트 인증하기 -> 퀘스트 상세 로직 임의 구현(후에 백엔드 작업에 따라 수정 가능성 있음)
 
### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다.
결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

- [ ] 정상 작동!

### 리뷰 요구사항

ex) 메인 페이지 중점으로 QA 진행 부탁드립니다.
